### PR TITLE
LAU-704 bump junit5PluginVersion for pitest

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 pitest {
   pitestVersion.set('1.9.11')
-  junit5PluginVersion.set('0.15')
+  junit5PluginVersion.set('1.1.1')
   targetClasses = ['uk.gov.hmcts.reform.*']
   excludedClasses = [
           'uk.gov.hmcts.reform.idam.madeup.*'


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-704

### Change description ###

After bumping pitest version, junit5PluginVersion was left at the old version. It needed to be updated as well (https://github.com/szpak/gradle-pitest-plugin#junit-5-plugin-for-pit-support-gradle-pitest-plugin-147)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
