### PR TITLE
LAU-741 split idam token and service token generators

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/idam/bdd/WireMockStubs.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/idam/bdd/WireMockStubs.java
@@ -24,12 +24,16 @@ public class WireMockStubs {
     @Value("${dummy-jwt}")
     private String dummyJwtToken;
 
+    @Value("${wiremock-debug:false}")
+    private boolean debugging;
+
     public final WireMockServer wiremock = WireMockInstantiator.INSTANCE.getWireMockServer();
 
     public void setupWireMock() {
-
-        wiremock.addMockServiceRequestListener(
-            WireMockStubs::requestReceived);
+        if (debugging) {
+            wiremock.addMockServiceRequestListener(
+                WireMockStubs::requestReceived);
+        }
         setupAuthorizationStub();
     }
 
@@ -94,13 +98,11 @@ public class WireMockStubs {
         wiremock.stubFor(
             WireMock
                 .get(WireMock.urlPathEqualTo(Constants.STALE_USERS_PATH))
-
                 .inScenario(scenarioName)
                 .whenScenarioStateIs(state)
                 .willReturn(
                     WireMock.jsonResponse(body, 200)
                 )
-
         );
     }
 
@@ -112,7 +114,6 @@ public class WireMockStubs {
                     WireMock.serverError()
                 )
         );
-
     }
 
     protected static void requestReceived(Request request, Response response) {

--- a/src/integrationTest/resources/application-test.yaml
+++ b/src/integrationTest/resources/application-test.yaml
@@ -4,3 +4,5 @@ idam:
     url: http://localhost:5000
 
 dummy-jwt: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+
+wiremock-debug: false

--- a/src/main/java/uk/gov/hmcts/reform/idam/service/remote/AuthRequestInterceptor.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/service/remote/AuthRequestInterceptor.java
@@ -4,17 +4,17 @@ import feign.RequestInterceptor;
 import feign.RequestTemplate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import uk.gov.hmcts.reform.idam.util.SecurityUtil;
+import uk.gov.hmcts.reform.idam.util.ServiceTokenGenerator;
 
 @Component
 @RequiredArgsConstructor
 public class AuthRequestInterceptor implements RequestInterceptor {
 
-    private final SecurityUtil securityUtil;
+    private final ServiceTokenGenerator serviceTokenGenerator;
 
     @Override
     public void apply(RequestTemplate template) {
         //template.header("Authorization", securityUtil.getIdamClientToken());
-        template.header("ServiceAuthorization", securityUtil.getServiceAuthorization());
+        template.header("ServiceAuthorization", serviceTokenGenerator.getServiceAuthToken());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/util/IdamTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/util/IdamTokenGenerator.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.idam.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
+import uk.gov.hmcts.reform.idam.exception.IdamAuthTokenGenerationException;
+import uk.gov.hmcts.reform.idam.parameter.ParameterResolver;
+import uk.gov.hmcts.reform.idam.service.remote.client.IdamClient;
+
+@Service
+@Slf4j
+@Getter
+@RequiredArgsConstructor
+public class IdamTokenGenerator {
+
+    public static final String BEARER = "Bearer ";
+    public static final String CLIENT_CREDENTIALS_GRANT = "client_credentials";
+    public static final String SCOPE = "archive-user view-archived-user delete-archived-user";
+
+    private final IdamClient idamClient;
+    private final ParameterResolver parameterResolver;
+
+    private String idamClientToken;
+
+    public void generateIdamToken() {
+        try {
+            TokenResponse tokenResponse = idamClient.getToken(
+                parameterResolver.getClientId(),
+                parameterResolver.getClientSecret(),
+                null,
+                CLIENT_CREDENTIALS_GRANT,
+                null,
+                null,
+                SCOPE
+            );
+            idamClientToken = BEARER + tokenResponse.accessToken;
+
+        } catch (final Exception exception) {
+            String msg = String.format("Unable to generate IDAM token due to error - %s", exception.getMessage());
+            log.error(msg, exception);
+            throw new IdamAuthTokenGenerationException(msg, exception);
+        }
+    }
+}

--- a/src/main/java/uk/gov/hmcts/reform/idam/util/SecurityUtil.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/util/SecurityUtil.java
@@ -2,75 +2,25 @@ package uk.gov.hmcts.reform.idam.util;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
-import uk.gov.hmcts.reform.idam.exception.IdamAuthTokenGenerationException;
-import uk.gov.hmcts.reform.idam.exception.ServiceAuthTokenGenerationException;
-import uk.gov.hmcts.reform.idam.parameter.ParameterResolver;
-import uk.gov.hmcts.reform.idam.service.remote.client.IdamClient;
 
 import java.util.concurrent.TimeUnit;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@EnableScheduling
 public class SecurityUtil {
-    public static final String BEARER = "Bearer ";
-    public static final String CLIENT_CREDENTIALS_GRANT = "client_credentials";
-    public static final String SCOPE = "archive-user view-archived-user delete-archived-user";
 
-    private final AuthTokenGenerator authTokenGenerator;
-    private final IdamClient idamClient;
-    private final ParameterResolver parameterResolver;
+    private final ServiceTokenGenerator serviceTokenGenerator;
 
-    private String idamClientToken;
-    private String serviceAuthToken;
-
-    public String getIdamClientToken() {
-        return idamClientToken;
-    }
-
-    public String getServiceAuthorization() {
-        return serviceAuthToken;
-    }
+    private final IdamTokenGenerator idamTokenGenerator;
 
     @Scheduled(fixedRate = 55, timeUnit = TimeUnit.MINUTES)
     public void generateTokens() {
-        generateIdamToken();
-        generateServiceToken();
-    }
-
-    private void generateServiceToken() {
-        try {
-            serviceAuthToken = authTokenGenerator.generate();
-        } catch (final Exception exception) {
-            String msg = String.format(
-                    "Unable to generate service auth token due to error - %s", exception.getMessage());
-            log.error(msg, exception);
-            throw new ServiceAuthTokenGenerationException(msg, exception);
-        }
-    }
-
-    private void generateIdamToken() {
-        try {
-            TokenResponse tokenResponse = idamClient.getToken(
-                parameterResolver.getClientId(),
-                parameterResolver.getClientSecret(),
-                null,
-                CLIENT_CREDENTIALS_GRANT,
-                null,
-                null,
-                SCOPE
-            );
-            idamClientToken = BEARER + tokenResponse.accessToken;
-
-        } catch (final Exception exception) {
-            String msg = String.format("Unable to generate IDAM token due to error - %s", exception.getMessage());
-            log.error(msg, exception);
-            throw new IdamAuthTokenGenerationException(msg, exception);
-        }
-
+        idamTokenGenerator.generateIdamToken();
+        serviceTokenGenerator.generateServiceToken();
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/idam/util/ServiceTokenGenerator.java
+++ b/src/main/java/uk/gov/hmcts/reform/idam/util/ServiceTokenGenerator.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.idam.util;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.idam.exception.ServiceAuthTokenGenerationException;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+@Getter
+public class ServiceTokenGenerator {
+
+    private final AuthTokenGenerator authTokenGenerator;
+
+    private String serviceAuthToken = "dummy token";
+
+    public void generateServiceToken() {
+        try {
+            serviceAuthToken = authTokenGenerator.generate();
+        } catch (final Exception exception) {
+            String msg = String.format(
+                "Unable to generate service auth token due to error - %s", exception.getMessage());
+            log.error(msg, exception);
+            throw new ServiceAuthTokenGenerationException(msg, exception);
+        }
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/idam/util/IdamTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/util/IdamTokenGeneratorTest.java
@@ -1,0 +1,82 @@
+package uk.gov.hmcts.reform.idam.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
+import uk.gov.hmcts.reform.idam.exception.IdamAuthTokenGenerationException;
+import uk.gov.hmcts.reform.idam.parameter.ParameterResolver;
+import uk.gov.hmcts.reform.idam.service.remote.client.IdamClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.idam.util.IdamTokenGenerator.BEARER;
+import static uk.gov.hmcts.reform.idam.util.IdamTokenGenerator.CLIENT_CREDENTIALS_GRANT;
+import static uk.gov.hmcts.reform.idam.util.IdamTokenGenerator.SCOPE;
+
+@ExtendWith(MockitoExtension.class)
+class IdamTokenGeneratorTest {
+    @Mock
+    IdamClient idamClient;
+
+    @Mock
+    ParameterResolver parameterResolver;
+
+    @InjectMocks
+    IdamTokenGenerator idamTokenGenerator;
+
+    @BeforeEach
+    void setUp() {
+        when(parameterResolver.getClientId()).thenReturn("ClientId");
+        when(parameterResolver.getClientSecret()).thenReturn("Client secret");
+    }
+
+    @Test
+    void shouldGetIdamToken() {
+        String token = "accessToken";
+        TokenResponse tokenResponse = new TokenResponse(
+            token,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        when(idamClient.getToken(
+            "ClientId",
+            "Client secret",
+            null,
+            CLIENT_CREDENTIALS_GRANT,
+            null,
+            null,
+            SCOPE
+        )).thenReturn(tokenResponse);
+        idamTokenGenerator.generateIdamToken();
+        assertThat(idamTokenGenerator.getIdamClientToken()).isEqualTo(BEARER + token);
+    }
+
+    @Test
+    void shouldThrowIdamAuthTokenGenerationException() {
+        doThrow(new IdamAuthTokenGenerationException("message")).when(idamClient).getToken(
+            "ClientId",
+            "Client secret",
+            null,
+            CLIENT_CREDENTIALS_GRANT,
+            null,
+            null,
+            SCOPE
+        );
+        IdamAuthTokenGenerationException thrown = assertThrows(
+            IdamAuthTokenGenerationException.class,
+            () -> idamTokenGenerator.generateIdamToken()
+        );
+
+        assertThat(thrown.getMessage()).contains("Unable to generate IDAM token due to error -");
+    }
+
+}

--- a/src/test/java/uk/gov/hmcts/reform/idam/util/SecurityUtilTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/util/SecurityUtilTest.java
@@ -5,83 +5,25 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
-import uk.gov.hmcts.reform.idam.client.models.TokenResponse;
-import uk.gov.hmcts.reform.idam.exception.IdamAuthTokenGenerationException;
-import uk.gov.hmcts.reform.idam.exception.ServiceAuthTokenGenerationException;
-import uk.gov.hmcts.reform.idam.parameter.ParameterResolver;
-import uk.gov.hmcts.reform.idam.service.remote.client.IdamClient;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.when;
-
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class SecurityUtilTest {
     @Mock
-    private AuthTokenGenerator tokenGenerator;
-    @Mock
-    private ParameterResolver parameterResolver;
-    @Mock
-    private IdamClient idamClient;
+    IdamTokenGenerator idamTokenGenerator;
 
-    private static final String TOKEN = "123456789";
-    private static final String ACCESS_TOKEN = "Bearer 1234";
-    public static final String IDAM_TOKEN = "1234";
-    public static final String CLIENT_CREDENTIALS_GRANT = "client_credentials";
-    public static final String SCOPE = "archive-user view-archived-user delete-archived-user";
+    @Mock
+    ServiceTokenGenerator serviceTokenGenerator;
 
     @InjectMocks
-    private SecurityUtil securityUtil;
+    SecurityUtil securityUtil;
 
     @Test
-    void shouldGetServiceAuthorization() {
-        TokenResponse tokenResponse = new TokenResponse(
-            IDAM_TOKEN,null,null,null,null,null);
-        when(tokenGenerator.generate()).thenReturn(TOKEN);
-        when(idamClient.getToken(null, null, null,
-                                 CLIENT_CREDENTIALS_GRANT, null, null,
-                                 SCOPE)).thenReturn(tokenResponse);
+    void shouldCallGenerators() {
         securityUtil.generateTokens();
-
-        assertThat(securityUtil.getServiceAuthorization()).isEqualTo(TOKEN);
-        assertThat(securityUtil.getIdamClientToken()).isEqualTo(ACCESS_TOKEN);
+        verify(idamTokenGenerator, times(1)).generateIdamToken();
+        verify(serviceTokenGenerator, times(1)).generateServiceToken();
     }
-
-    @Test
-    void shouldThrowServiceAuthTokenGenerationException() {
-        TokenResponse tokenResponse = new TokenResponse(
-            IDAM_TOKEN,null,null,null,null,null);
-        when(idamClient.getToken(null, null, null,
-                                 CLIENT_CREDENTIALS_GRANT, null, null,
-                                 SCOPE))
-            .thenReturn(tokenResponse);
-        doThrow(new ServiceAuthTokenGenerationException(TOKEN))
-            .when(tokenGenerator).generate();
-
-        ServiceAuthTokenGenerationException thrown = assertThrows(
-            ServiceAuthTokenGenerationException.class,
-            () -> securityUtil.generateTokens()
-        );
-
-        assertThat(thrown.getMessage()).contains("Unable to generate service auth token due to error -");
-    }
-
-    @Test
-    void shouldThrowIdamAuthTokenGenerationException() {
-        doThrow(new IdamAuthTokenGenerationException(TOKEN))
-            .when(idamClient).getToken(null, null, null,
-                                 CLIENT_CREDENTIALS_GRANT, null, null,
-                                 SCOPE);
-
-        IdamAuthTokenGenerationException thrown = assertThrows(
-            IdamAuthTokenGenerationException.class,
-            () -> securityUtil.generateTokens()
-        );
-
-        assertThat(thrown.getMessage()).contains("Unable to generate IDAM token due to error -");
-    }
-
 }

--- a/src/test/java/uk/gov/hmcts/reform/idam/util/ServiceTokenGeneratorTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/idam/util/ServiceTokenGeneratorTest.java
@@ -1,0 +1,46 @@
+package uk.gov.hmcts.reform.idam.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.hmcts.reform.authorisation.generators.AuthTokenGenerator;
+import uk.gov.hmcts.reform.idam.exception.ServiceAuthTokenGenerationException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class ServiceTokenGeneratorTest {
+
+    @Mock
+    AuthTokenGenerator authTokenGenerator;
+
+    @InjectMocks
+    ServiceTokenGenerator serviceTokenGenerator;
+
+    @Test
+    void shouldGetServiceToken() {
+        String token = "serviceToken";
+        when(authTokenGenerator.generate()).thenReturn(token);
+        serviceTokenGenerator.generateServiceToken();
+        assertThat(serviceTokenGenerator.getServiceAuthToken()).isEqualTo(token);
+    }
+
+    @Test
+    void shouldThrowServiceAuthTokenGenerationException() {
+        doThrow(new ServiceAuthTokenGenerationException("message"))
+            .when(authTokenGenerator).generate();
+
+        ServiceAuthTokenGenerationException thrown = assertThrows(
+            ServiceAuthTokenGenerationException.class,
+            () -> serviceTokenGenerator.generateServiceToken()
+        );
+
+        assertThat(thrown.getMessage()).contains("Unable to generate service auth token due to error -");
+    }
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/LAU-741

### Change description ###

Split idam token and service token generators to break circular dependencies coming from Feign client request interceptor

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
